### PR TITLE
Eliminate debug messages or convert to mono_trace

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -5444,7 +5444,6 @@ emit_and_reloc_code (MonoAotCompile *acfg, MonoMethod *method, guint8 *code, gui
 			case MONO_PATCH_INFO_GOT_OFFSET: {
 				int code_size;
  
-fprintf(stderr,"code: %p i: 0x%08x size: 0x%08xi INST_LEN: %d\n",code,i,code_size,INST_LEN);fflush(stderr);
 				arch_emit_got_offset (acfg, code + i, &code_size);
 				i += code_size - INST_LEN;
 				skip = TRUE;
@@ -5838,7 +5837,6 @@ encode_patch (MonoAotCompile *acfg, MonoJumpInfo *patch_info, guint8 *buf, guint
 		guint32 image_index = get_image_index (acfg, patch_info->data.token->image);
 		guint32 token = patch_info->data.token->token;
 		g_assert (mono_metadata_token_code (token) == MONO_TOKEN_STRING);
-fprintf(stderr,"LDSTR - index: 0x%08x p: %p\n",image_index,p);fflush(stderr);
 		encode_value (image_index, p, &p);
 		encode_value (patch_info->data.token->token - MONO_TOKEN_STRING, p, &p);
 		break;

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -3525,7 +3525,6 @@ decode_patch (MonoAotModule *aot_module, MonoMemPool *mp, MonoJumpInfo *ji, guin
 		mono_error_cleanup (&error); /* FIXME don't swallow the error */
 		if (!ji->data.klass)
 			goto cleanup;
-fprintf(stderr,"VTABLE - klass: %s\n",ji->data.klass->name);
 		break;
 	case MONO_PATCH_INFO_DELEGATE_TRAMPOLINE:
 		ji->data.del_tramp = (MonoDelegateClassMethodPair *)mono_mempool_alloc0 (mp, sizeof (MonoDelegateClassMethodPair));
@@ -3588,7 +3587,6 @@ fprintf(stderr,"VTABLE - klass: %s\n",ji->data.klass->name);
 		if (!image)
 			goto cleanup;
 		ji->data.token = mono_jump_info_token_new (mp, image, MONO_TOKEN_STRING + decode_value (p, &p));
-fprintf(stderr,"LDSTR - image: %p token: 0x%08x\n",image,ji->data.token);fflush(stderr);
 		break;
 	case MONO_PATCH_INFO_RVA:
 	case MONO_PATCH_INFO_DECLSEC:
@@ -3739,7 +3737,7 @@ fprintf(stderr,"LDSTR - image: %p token: 0x%08x\n",image,ji->data.token);fflush(
 		break;
 	default:
 		g_warning ("unhandled type %d", ji->type);
-fprintf(stderr, "ji: %p ip: %p type: %d target: %p from: %p\n",ji,ji->ip.i,ji->type,ji->data.target,__builtin_return_address(0));
+mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_AOT, "ji: %p ip: %p type: %d target: %p from: %p\n",ji,ji->ip.i,ji->type,ji->data.target,__builtin_return_address(0));
 		g_assert_not_reached ();
 	}
 
@@ -4230,7 +4228,7 @@ init_method (MonoAotModule *amodule, guint32 method_index, MonoMethod *method, M
 					addr = mono_create_ftnptr (domain, addr);
 				mono_memory_barrier ();
 				got [got_slots [pindex]] = addr;
-fprintf(stderr,"GOT: %p got_slots[%d]: 0x%08x got [got_slots [%d]]: 0x%08x\n",got,pindex,got_slots[pindex],pindex,got[got_slots[pindex]]);fflush(stderr);
+mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_AOT, "GOT: %p got_slots[%d]: 0x%08x got [got_slots [%d]]: 0x%08x\n",got,pindex,got_slots[pindex],pindex,got[got_slots[pindex]]);
 				if (ji->type == MONO_PATCH_INFO_METHOD_JUMP)
 					register_jump_target_got_slot (domain, ji->data.method, &(got [got_slots [pindex]]));
 			}
@@ -4897,7 +4895,7 @@ mono_aot_get_plt_entry (guint8 *code)
 
 	return NULL;
 #else
-fprintf (stderr,"target: %p plt_start: %p plt_end: %p\n",target,amodule->plt,amodule->plt_end);fflush(stderr);
+mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_AOT, "target: %p plt_start: %p plt_end: %p\n",target,amodule->plt,amodule->plt_end);
 	if ((target >= (guint8*)(amodule->plt)) && (target < (guint8*)(amodule->plt_end)))
 		return target;
 	else

--- a/mono/mini/cstpool-sh4.c
+++ b/mono/mini/cstpool-sh4.c
@@ -457,7 +457,7 @@ sh4_emit_pool_lowperf(MonoCompile *cfg, CstPool_Context context, guint8 **pcval)
 		sh4_nop(pcval);	     /* delay slot.	   sz = 4   */
 	}
 
-	if(((guint32)*pcval & 0x3)) {                     /* sz<=6   */
+	while (((guint32)*pcval % 4) != 0) {
 		sh4_nop(pcval);      /* Align constant pool */
 	}
 
@@ -555,7 +555,7 @@ sh4_emit_pool_lowperf(MonoCompile *cfg, CstPool_Context context, guint8 **pcval)
 		sh4_bra_label(&patch1, *pcval);
 	}
 
-	if(cur_pool->pool_nbcst_emitted > SH4_CSTPOOL_FILL_LIMIT) {
+	if (cur_pool->pool_nbcst_emitted > SH4_CSTPOOL_FILL_LIMIT) {
 		cur_pool->state = cstpool_allocated;
 	}
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -11256,7 +11256,6 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				int add_reg = alloc_ireg_mp (cfg);
 
 				EMIT_NEW_BIALU_IMM (cfg, iargs [0], OP_PADD_IMM, add_reg, ins->dreg, MONO_STRUCT_OFFSET (MonoArray, vector));
-// fprintf(stderr,"EMIT_NEW_AOTCONST_TOKEN\n");
 				if (cfg->compile_aot) {
 					EMIT_NEW_AOTCONST_TOKEN (cfg, iargs [1], MONO_PATCH_INFO_RVA, method->klass->image, GPOINTER_TO_UINT(field_token), STACK_PTR, NULL);
 				} else {

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2477,8 +2477,8 @@ mono_handle_native_crash (const char *signal, void *ctx, MONO_SIG_HANDLER_INFO_T
 #endif
 	MonoJitTlsData *jit_tls = (MonoJitTlsData *)mono_tls_get_jit_tls ();
 
-// struct sigcontext *sigctx = ctx;
-// fprintf(stderr,"addr: %p PC: 0x%08x PR: 0x%08x\n",info->si_addr,sigctx->sc_pc,sigctx->sc_pr);
+struct sigcontext *sigctx = ctx;
+mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_AOT, "addr: %p PC: 0x%08x PR: 0x%08x\n",info->si_addr,sigctx->sc_pc,sigctx->sc_pr);
 	gboolean is_sigsegv = !strcmp ("SIGSEGV", signal);
 
 	if (handling_sigsegv && is_sigsegv)

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -1208,7 +1208,7 @@ mono_patch_info_hash (gconstpointer data)
 		return (ji->type << 8) | mono_signature_hash (ji->data.sig);
 	default:
 		printf ("info type: %d\n", ji->type);
-		mono_print_ji (ji); printf ("\n");
+		mono_print_ji (ji); printf (" ji: %p target: %p ip: %p\n",ji,ji->data.target,ji->ip.p);
 		g_assert_not_reached ();
 		return 0;
 	}
@@ -2794,7 +2794,7 @@ MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 	void *info = NULL;
 #endif
 	MONO_SIG_HANDLER_GET_CONTEXT;
-// fprintf(stderr,"addr: %p\n",info->si_addr);
+mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_AOT, "addr: %p\n",info->si_addr);
 
 #if defined(MONO_ARCH_SOFT_DEBUG_SUPPORTED) && defined(HAVE_SIG_INFO)
 	if (mono_arch_is_single_step_event (info, ctx)) {

--- a/mono/mini/mini-sh4.c
+++ b/mono/mini/mini-sh4.c
@@ -4018,19 +4018,20 @@ mono_arch_output_basic_block(MonoCompile *cfg, MonoBasicBlock *basic_block)
 				while (((guint32) buffer % 4) != 0)	// .align 2
 					sh4_nop (&buffer);	
 				sh4_die (&buffer);	// 0: .long offset
+				sh4_die (&buffer);	//    .....
 				sh4_die (&buffer);	// 1: jsr   @r3
 				sh4_die (&buffer);	//    nop       
-				break;
+			} else {
+				/* Please, update mono_arch_patch_callsite() according
+				   to any changes made on this code-generation. CV */
+
+				/* TODO - CV : optimize with sh4_bsr if possible. */
+
+				sh4_cstpool_add(cfg, &buffer, type, target, sh4_temp);
+
+				sh4_jsr_indRx(&buffer, sh4_temp);
+				sh4_nop(&buffer); /* delay slot */
 			}
-			/* Please, update mono_arch_patch_callsite() according
-			   to any changes made on this code-generation. CV */
-
-			/* TODO - CV : optimize with sh4_bsr if possible. */
-
-			sh4_cstpool_add(cfg, &buffer, type, target, sh4_temp);
-
-			sh4_jsr_indRx(&buffer, sh4_temp);
-			sh4_nop(&buffer); /* delay slot */
 
 			if (inst->opcode == OP_FCALL &&
 			    call->signature->pinvoke) {
@@ -4232,8 +4233,10 @@ mono_arch_output_basic_block(MonoCompile *cfg, MonoBasicBlock *basic_block)
 			sh4_die(&buffer); /* patch slot for : bf/t_label "skip_jump" */
 
 			if (type == MONO_PATCH_INFO_EXC) {
-				/* sh4_mov(&buffer, sh4_pc, MONO_SH4_REG_FIRST_ARG + 1); */
-				sh4_cstpool_add(cfg, &buffer, MONO_PATCH_INFO_IP, (gconstpointer)(buffer - cfg->native_code), MONO_SH4_REG_FIRST_ARG + 1);
+				sh4_mov (&buffer, sh4_r0, sh4_temp);
+				sh4_mova_dispPC_R0 (&buffer, 0);
+				sh4_mov (&buffer, sh4_r0, (MONO_SH4_REG_FIRST_ARG + 1));
+				sh4_mov (&buffer, sh4_temp, sh4_r0);
 			}
 
 			sh4_cstpool_add(cfg, &buffer, type, target, sh4_temp);


### PR DESCRIPTION
Got rid of fprintfs and replaced some with mono_trace and eliminated the others.